### PR TITLE
Added `--include-css` option to Stylus compiler

### DIFF
--- a/Stylus.lrplugin/manifest.json
+++ b/Stylus.lrplugin/manifest.json
@@ -47,6 +47,12 @@
           "Type": "checkbox",
           "Title": "Emit line numbers debug info (--line-numbers)",
           "OnArgument": "--line-numbers"
+        },
+        {
+          "Id": "include-css",
+          "Type": "checkbox",
+          "Title": "Include regular css on @import (--include-css)",
+          "OnArgument": "--include-css"
         }
       ]
     }


### PR DESCRIPTION
Commit for [this issue](http://help.livereload.com/discussions/suggestions/71-add-include-css-option-to-stylus-compiler-settings).

> By default Stylus don't include the @imports for .css files. However, there is an option in it's commandline interface — --include-css — that makes it to include those files.
> 
> This can be useful when you want to reduce the number of request to server and want to include some CSS in your Stylus code.
