### PR TITLE
Sass plugin ZURB mixin unit typo correction

### DIFF
--- a/SASS.lrplugin/lib/ZURB-foundation/stylesheets/ZURB/includes/_mixins.sass
+++ b/SASS.lrplugin/lib/ZURB-foundation/stylesheets/ZURB/includes/_mixins.sass
@@ -15,10 +15,10 @@
 @mixin font-size($size, $is-important: false)
   @if $is-important
     font-size: $size + px !important
-    font-size: ($size / 10) + rem !important
+    font-size: ($size / 10) + em !important
   @else
     font-size: $size + px 
-    font-size: ($size / 10) + rem
+    font-size: ($size / 10) + em
 
 // WebKit: font-smoothing
 // Values: none, antialiased (default), subpixel-antialiased


### PR DESCRIPTION
Sass plugin ZURB _mixins.sass had a unit typo "rem" instead of "em." This commit corrects that.
