### PR TITLE
SassC/libsass plugin for LiveReload

### DIFF
--- a/SassC.lrplugin/manifest.json
+++ b/SassC.lrplugin/manifest.json
@@ -1,0 +1,152 @@
+{
+  "actions": [
+    {
+      "type": "compile-file",
+      "id": "sass",
+      "name": "Sass",
+      "input": "*.scss",
+      "output": "*.css",
+      "packages": [],
+      "info": [
+        {
+          "versions": "*",
+          "cmdline": [
+            "/usr/local/bin/sassc",
+            "$(additional)",
+            "$(src_path)",
+            "$(dst_path)"
+          ],
+          "errors": [
+            {
+              "pattern": "Syntax error: ((message))\\n\\s+on line ((line)) of ((file))\\n"
+            },
+            {
+              "pattern": "Exception on line ((line)): ((message))\\n"
+            },
+            {
+              "pattern": "Syntax error: ((message))\\n\\s+Load path:.*\\n\\s+on line ((line)) of ((file))\\n"
+            },
+            {
+              "pattern": "Errno::ENOENT: ((message)) - ((file))"
+            },
+            {
+              "pattern": "ZeroDivisionError: ((message))"
+            }
+          ],
+          "options": [
+            {
+              "type": "checkbox",
+              "id": "sourcemap",
+              "label": "Generate sourcemap",
+              "args": "--sourcemap"
+            },
+            {
+              "type": "checkbox",
+              "id": "debug-info",
+              "label": "Include comments showing scss line numbers",
+              "args": "--line-numbers"
+            },
+            {
+              "id": "output-style",
+              "type": "select",
+              "label": "Output style:",
+              "items": [
+                {
+                  "id": "nested",
+                  "label": "Nested",
+                  "args": "--style nested"
+                },
+                {
+                  "id": "compressed",
+                  "label": "Compressed",
+                  "args": "--style compressed"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "LRCompilers": [
+    {
+      "CommandLine": [
+        "/usr/local/bin/sassc",
+        "$(additional)",
+        "$(src_path)",
+        "$(dst_path)"
+      ],
+      "DestinationExtension": "css",
+      "Errors": [
+        "Syntax error: ((message))\\n\\s+on line ((line)) of ((file))\\n",
+        "Exception on line ((line)): ((message))\\n",
+        "Syntax error: ((message))\\n\\s+Load path:.*\\n\\s+on line ((line)) of ((file))\\n",
+        "Errno::ENOENT: ((message)) - ((file))",
+        "ZeroDivisionError: ((message))"
+      ],
+      "Warnings": [
+        "WARNING on line ((line)) of ((file)):\\n((message))\\n"
+      ],
+      "Extensions": [
+        "scss"
+      ],
+      "Name": "SASS",
+      "ExpectedOutputDirectories": [
+        "css",
+        "styles",
+        "stylesheet",
+        "stylesheets"
+      ],
+      "ImportRegExps": [
+        "@import\\s*\"([^\"]+)\"",
+        "@import\\s*'([^']+)'",
+        "@import\\s+([\\w./-]+)"
+      ],
+      "ImportContinuationRegExps": [
+        ",\\s*\"([^\"]+)\"",
+        ",\\s*'([^']+)'",
+        ",\\s*([\\w./-]+)"
+      ],
+      "DefaultImportedExts": [
+        "scss"
+      ],
+      "ImportToFileMappings": [
+        "$(dir)/$(file)",
+        "$(dir)/_$(file)"
+      ],
+      "NonImportedExts": [
+        "css"
+      ],
+      "Options": [
+        {
+          "Id": "sourcemap",
+          "Type": "checkbox",
+          "Title": "Generate sourcemap",
+          "OnArgument": "--sourcemap"
+        },
+        {
+          "Id": "debug-info",
+          "Type": "checkbox",
+          "Title": "Include comments showing scss line numbers",
+          "OnArgument": "--line-numbers"
+        },
+        {
+          "Id": "output-style",
+          "Type": "select",
+          "Items": [
+            {
+              "Id": "nested",
+              "Title": "Nested output style",
+              "Argument": "--style nested"
+            },
+            {
+              "Id": "compressed",
+              "Title": "Compressed output style",
+              "Argument": "--style compressed"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Built by making a few straightforward mods to existing SASS.lrplugin/manifest.json. Essentially, I changed the bits that point to the compiler, made the user-selectable options consistent with those of the SassC/Libsass compiler, lopped of the Compass block at the bottom, and didn't mess with any of the syntax checking or the error trapping and handling. The compiler is Libsass 3.1.0 Bulleit Bottle (https://github.com/sass/libsass/releases) wrapped in SassC 3.1.0 Bulleit Bottle (https://github.com/sass/sassc/releases) using shell script from https://gist.github.com/ryanjbonnell/e03f3cf1e9f6b3cf402b and is linked to /usr/local/bin/sassc on my MacPro6,1 running OS X 10.10. I put SassC.lrplugin/manifest.json in the LiveReload Resources directory in place of the SASS.lrplugin which comes with LiveReload 2.3.65. It would be nice to integrate the SassC/Libsass compiler into the original SASS.lrplugin and give the user a choice between SassC/Libsass and Ruby SASS, but this may be more than I'm up to and is probably more than I have time for right now. Along with fswatch (https://github.com/emcrisostomo/fswatch) triggering rsync updates to my remote server, I have all the functionality I was looking for for front-end web development... now I just have to learn to be a front-end developer!

I'm hoping one of you guys who really know what you're doing (@andreyvit, @kizu) will have a look at this and tell me whether I've screwed up in any obvious way (codewise or with GitHub protocol - my first time doing this). If there is something else I should do, point me in the right direction and I'll give it a try! Thanks.